### PR TITLE
Deploy basic exposed Jenkins instance

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: jenkins
+  namespace: jenkins
+  labels:
+    app: jenkins
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: jenkins
+  template:
+    metadata:
+      labels:
+        app: jenkins
+    spec:
+      containers:
+        - name: jenkins
+          image: jenkins/jenkins:2.222
+          ports:
+            - containerPort: 8080
+            - containerPort: 50000
+          volumeMounts:
+            - name: jenkins-home
+              mountPath: /var/jenkins_home
+      securityContext:
+        fsGroup: 1000
+      volumes:
+        - name: jenkins-home
+          persistentVolumeClaim:
+            claimName: jenkins-home

--- a/ingress.yaml
+++ b/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: jenkins
+  namespace: jenkins
+  labels:
+    app: jenkins
+spec:
+  rules:
+    - host: jenkins.byondlabs.io
+      http:
+        paths:
+          - backend:
+              serviceName: jenkins
+              servicePort: 8080

--- a/namespace.yaml
+++ b/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: jenkins
+  labels:
+    app: jenkins
+spec: {}

--- a/persistent-volume-claim.yaml
+++ b/persistent-volume-claim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: jenkins-home
+  namespace: jenkins
+  labels:
+    app: jenkins
+spec:
+  resources:
+    requests:
+      storage: 5Gi
+  accessModes:
+    - ReadWriteOnce

--- a/service.yaml
+++ b/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: jenkins
+  namespace: jenkins
+  labels:
+    app: jenkins
+spec:
+  selector:
+    app: jenkins
+  ports:
+    - name: web
+      protocol: TCP
+      port: 8080
+      targetPort: 8080
+    - name: jnlp
+      protocol: TCP
+      port: 50000
+      targetPort: 50000


### PR DESCRIPTION
This instance will start unconfigured. Further commits will ensure that
this instance can be configured from a clean persistent volume claim.

The ingress is hardwired to expose to jenkins.byondlabs.io. Within our
infrastructure Cloudflare provides SSL termination. An SSL certificate
on the ingress may be applied later for full end-to-end encryption.