### PR TITLE
Secure ingress with LetsEncrypt TLS

### DIFF
--- a/deploy-jenkins.yaml
+++ b/deploy-jenkins.yaml
@@ -50,7 +50,14 @@ metadata:
   namespace: jenkins
   labels:
     app: jenkins
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
+  tls:
+    - hosts:
+        - jenkins.byondlabs.io
+      secretName: jenkins-tls
   rules:
     - host: jenkins.byondlabs.io
       http:


### PR DESCRIPTION
This assumes that cert-manager is employed within the cluster, to 
automatically provision the TLS certificate, and a ClusterIssuer of 
letsencrypt-prod has been created.

This change allows us to use strict end-to-end Cloudflare encryption.