### PR TITLE
Set up admin account and allow anon read

### DIFF
--- a/config/init.groovy.d/admin.groovy
+++ b/config/init.groovy.d/admin.groovy
@@ -1,0 +1,11 @@
+import hudson.security.FullControlOnceLoggedInAuthorizationStrategy
+import hudson.security.HudsonPrivateSecurityRealm
+import jenkins.model.Jenkins
+
+def hudsonRealm = new HudsonPrivateSecurityRealm(false)
+hudsonRealm.createAccount('admin', System.getenv('JENKINS_ADMIN_PASSWORD'))
+Jenkins.instance.setSecurityRealm(hudsonRealm)
+def strategy = new FullControlOnceLoggedInAuthorizationStrategy()
+strategy.setAllowAnonymousRead(true)
+Jenkins.instance.setAuthorizationStrategy(strategy)
+Jenkins.instance.save()

--- a/deploy-jenkins.yaml
+++ b/deploy-jenkins.yaml
@@ -101,7 +101,13 @@ spec:
     spec:
       initContainers:
         - name: copy-scripts
-          image: byond/packaging-jenkins-config:v4
+          image: byond/packaging-jenkins-config:v5
+          env:
+            - name: JENKINS_ADMIN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: jenkins-admin-account
+                  key: password
           volumeMounts:
             - name: jenkins-scripts
               mountPath: /usr/share/jenkins/ref


### PR DESCRIPTION
This sets up the admin account from a supplied secret called 
jenkins-admin-account.