### PR TITLE
Upgrade to Jenkins 2.226

### DIFF
--- a/base/deployments.yaml
+++ b/base/deployments.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: jenkins
-          image: jenkins/jenkins:2.222
+          image: jenkins/jenkins:2.226
           ports:
             - containerPort: 8080
             - containerPort: 50000


### PR DESCRIPTION
This is to pick up security fixes and general improvements.